### PR TITLE
Fixed CPU/CUDA compatibility issue

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -60,8 +60,8 @@ if __name__ == '__main__':
     model = config.get_model(cfg, device=device, len_dataset=len(dataset))
 
     checkpoint_io = CheckpointIO(out_dir, model=model)
-    checkpoint_io.load(cfg['test']['model_file'])
-
+    checkpoint_io.load(cfg['test']['model_file'], device=device)
+    
     # Generator
     generator = config.get_generator(model, cfg, device=device)
 

--- a/im2mesh/checkpoints.py
+++ b/im2mesh/checkpoints.py
@@ -52,18 +52,18 @@ class CheckpointIO(object):
             filename_backup = os.path.join(backup_dir, '%s.pt' % ts)
             shutil.copy(filename, filename_backup)
 
-    def load(self, filename):
+    def load(self, filename, device):
         '''Loads a module dictionary from local file or url.
 
         Args:
             filename (str): name of saved module dictionary
         '''
         if is_url(filename):
-            return self.load_url(filename)
+            return self.load_url(filename, device)
         else:
-            return self.load_file(filename)
+            return self.load_file(filename, device)
 
-    def load_file(self, filename):
+    def load_file(self, filename, device):
         '''Loads a module dictionary from file.
 
         Args:
@@ -76,13 +76,13 @@ class CheckpointIO(object):
         if os.path.exists(filename):
             print(filename)
             print('=> Loading checkpoint from local file...')
-            state_dict = torch.load(filename)
+            state_dict = torch.load(filename, map_location=torch.device(device))
             scalars = self.parse_state_dict(state_dict)
             return scalars
         else:
             raise FileExistsError
 
-    def load_url(self, url):
+    def load_url(self, url, device):
         '''Load a module dictionary from url.
 
         Args:
@@ -90,7 +90,7 @@ class CheckpointIO(object):
         '''
         print(url)
         print('=> Loading checkpoint from url...')
-        state_dict = model_zoo.load_url(url, progress=True)
+        state_dict = model_zoo.load_url(url, progress=True, map_location=torch.device(device))
         scalars = self.parse_state_dict(state_dict)
         return scalars
 


### PR DESCRIPTION
Fixed the below error in loading the trained model on CPU. 

```
(dvr) PS ~\differentiable_volumetric_rendering> python generate.py configs/demo/demo_combined.yaml --no-cuda
https://s3.eu-central-1.amazonaws.com/avg-projects/differentiable_volumetric_rendering/models/single_view_reconstruction/multi-view-supervision/ours_combined-af2bce07.pt
=> Loading checkpoint from url...
Traceback (most recent call last):
  File "generate.py", line 63, in <module>
    checkpoint_io.load(cfg['test']['model_file'])
  File "differentiable_volumetric_rendering\im2mesh\checkpoints.py", line 62, in load
    return self.load_url(filename)
  File "differentiable_volumetric_rendering\im2mesh\checkpoints.py", line 93, in load_url
    state_dict = model_zoo.load_url(url, progress=True)
  File "anaconda3\envs\dvr\lib\site-packages\torch\hub.py", line 509, in load_state_dict_from_url
    return torch.load(cached_file, map_location=map_location)
  File "anaconda3\en\dvr\lib\site-packages\torch\serialization.py", line 593, in load
    return _legacy_load(opened_file, map_location, pickle_module, **pickle_load_args)
  File "anaconda3\envs\dvr\lib\site-packages\torch\serialization.py", line 773, in _legacy_load
    result = unpickler.load()
  File "anaconda3\envs\dvr\lib\site-packages\torch\serialization.py", line 729, in persistent_load
    deserialized_objects[root_key] = restore_location(obj, location)
  File "anaconda3\envs\dvr\lib\site-packages\torch\serialization.py", line 178, in default_restore_location
    result = fn(storage, location)
  File "anaconda3\envs\dvr\lib\site-packages\torch\serialization.py", line 154, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "anaconda3\envs\dvr\lib\site-packages\torch\serialization.py", line 138, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```